### PR TITLE
Allow for optional (non-decimal) base

### DIFF
--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -1,36 +1,34 @@
 defmodule Luhn do
   require Integer
 
-  @spec valid?(integer, 2..36, 2..36 | nil) :: boolean
-  def valid?(number, base \\ 10, mod \\ nil) do
-    checksum(number, base, mod)
+  @spec valid?(integer, 2..36) :: boolean
+  def valid?(number, base \\ 10) do
+    checksum(number, base)
     |> Kernel.== 0
   end
 
-  def checksum(number, base \\ 10, mod \\ nil)
+  def checksum(number, base \\ 10)
 
-  @spec checksum(integer, 2..36, 2..36 | nil) :: integer
-  def checksum(number, base, mod) when is_integer(number) do
+  @spec checksum(integer, 2..36) :: integer
+  def checksum(number, base) when is_integer(number) do
     number
     |> Integer.to_string(base)
-    |> checksum(base, mod)
+    |> checksum(base)
   end
 
-  @spec checksum(String.t, 2..36, 2..36 | nil) :: integer
-  def checksum(number, base, mod) do
-    mod = mod || base
-
+  @spec checksum(String.t, 2..36) :: integer
+  def checksum(number, base) do
     number
     |> String.split("", trim: true)
     |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n, base)|acc] end)
-    |> double(mod)
-    |> rem mod
+    |> double(base)
+    |> rem base
   end
 
   defp double([], _), do: 0
   defp double([x], _), do: x
-  defp double([x,y|tail], mod), do: x + sum(y * 2, mod) + double(tail, mod)
+  defp double([x,y|tail], base), do: x + sum(y * 2, base) + double(tail, base)
 
-  defp sum(number, mod) when number >= mod, do: sum(number - mod + 1, mod)
+  defp sum(number, base) when number >= base, do: number - base + 1
   defp sum(number, _), do: number
 end

--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -6,13 +6,20 @@ defmodule Luhn do
     |> Kernel.== 0
   end
 
-  def checksum(number) when is_integer(number) do
-    Integer.to_string(number) |> checksum
+  def checksum(number, base \\ 10)
+
+  @spec checksum(integer, 2..36) :: integer
+  def checksum(number, base) when is_integer(number) do
+    number
+    |> Integer.to_string(base)
+    |> checksum(base)
   end
 
-  def checksum(number) do
-    String.split(number, "", trim: true)
-    |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n)|acc] end)
+  @spec checksum(String.t, 2..36) :: integer
+  def checksum(number, base) do
+    number
+    |> String.split("", trim: true)
+    |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n, base)|acc] end)
     |> double
     |> rem 10
   end
@@ -21,6 +28,6 @@ defmodule Luhn do
   defp double([x]), do: x
   defp double([x,y|tail]), do: x + sum(y * 2) + double(tail)
 
-  defp sum(number) when number >= 10, do: number - 9
+  defp sum(number) when number >= 10, do: sum(number - 9)
   defp sum(number), do: number
 end

--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -1,33 +1,36 @@
 defmodule Luhn do
   require Integer
 
-  def valid?(number) do
-    checksum(number)
+  @spec valid?(integer, 2..36, 2..36 | nil) :: boolean
+  def valid?(number, base \\ 10, mod \\ nil) do
+    checksum(number, base, mod)
     |> Kernel.== 0
   end
 
-  def checksum(number, base \\ 10)
+  def checksum(number, base \\ 10, mod \\ nil)
 
-  @spec checksum(integer, 2..36) :: integer
-  def checksum(number, base) when is_integer(number) do
+  @spec checksum(integer, 2..36, 2..36 | nil) :: integer
+  def checksum(number, base, mod) when is_integer(number) do
     number
     |> Integer.to_string(base)
-    |> checksum(base)
+    |> checksum(base, mod)
   end
 
-  @spec checksum(String.t, 2..36) :: integer
-  def checksum(number, base) do
+  @spec checksum(String.t, 2..36, 2..36 | nil) :: integer
+  def checksum(number, base, mod) do
+    mod = mod || base
+
     number
     |> String.split("", trim: true)
     |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n, base)|acc] end)
-    |> double
-    |> rem 10
+    |> double(mod)
+    |> rem mod
   end
 
-  defp double([]), do: 0
-  defp double([x]), do: x
-  defp double([x,y|tail]), do: x + sum(y * 2) + double(tail)
+  defp double([], _), do: 0
+  defp double([x], _), do: x
+  defp double([x,y|tail], mod), do: x + sum(y * 2, mod) + double(tail, mod)
 
-  defp sum(number) when number >= 10, do: sum(number - 9)
-  defp sum(number), do: number
+  defp sum(number, mod) when number >= mod, do: sum(number - mod + 1, mod)
+  defp sum(number, _), do: number
 end

--- a/test/luhn_test.exs
+++ b/test/luhn_test.exs
@@ -45,8 +45,22 @@ defmodule LuhnTest do
   end
 
   test "Invalid numbers" do
-    assert !Luhn.valid? "123456789123456"
-    assert !Luhn.valid? 123456789123456
-    assert !Luhn.valid? "4111111511111112"
+    refute Luhn.valid? "123456789123456"
+    refute Luhn.valid? 123456789123456
+    refute Luhn.valid? "4111111511111112"
+  end
+
+  test "Hexadecimal base" do
+    assert Luhn.valid? "abc12392c", 16
+    assert Luhn.valid? "abc1239", 16
+  end
+
+  test "Invalid with hexadecimal base" do
+    refute Luhn.valid? "abc12392b", 16
+    refute Luhn.valid? "abc123a", 16
+  end
+
+  test "Hexadecimal base and mod 10" do
+    assert Luhn.valid? "0F04871513130338972614312C30307", 16, 10
   end
 end

--- a/test/luhn_test.exs
+++ b/test/luhn_test.exs
@@ -45,9 +45,9 @@ defmodule LuhnTest do
   end
 
   test "Invalid numbers" do
-    refute Luhn.valid? "123456789123456"
-    refute Luhn.valid? 123456789123456
-    refute Luhn.valid? "4111111511111112"
+    assert !Luhn.valid? "123456789123456"
+    assert !Luhn.valid? 123456789123456
+    assert !Luhn.valid? "4111111511111112"
   end
 
   test "Hexadecimal base" do
@@ -56,11 +56,7 @@ defmodule LuhnTest do
   end
 
   test "Invalid with hexadecimal base" do
-    refute Luhn.valid? "abc12392b", 16
-    refute Luhn.valid? "abc123a", 16
-  end
-
-  test "Hexadecimal base and mod 10" do
-    assert Luhn.valid? "0F04871513130338972614312C30307", 16, 10
+    assert !Luhn.valid? "abc12392b", 16
+    assert !Luhn.valid? "abc123a", 16
   end
 end


### PR DESCRIPTION
Checksums of hexadecimal input such as "FF" can be calculated by
passing base 16. If the base is not given, base 10 will be used.
