### PR TITLE
Random string handling

### DIFF
--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -3,11 +3,11 @@ defmodule Luhn do
 
   @spec valid?(integer, 2..36) :: boolean
   def valid?(number, base \\ 10) do
-    checksum(number, base)
-    |> Kernel.== 0
+    case checksum(number, base) do
+      {:ok, checksum} -> checksum == 0
+      :error -> false
+    end
   end
-
-  def checksum(number, base \\ 10)
 
   @spec checksum(integer, 2..36) :: integer
   def checksum(number, base) when is_integer(number) do
@@ -17,18 +17,27 @@ defmodule Luhn do
   end
 
   @spec checksum(String.t, 2..36) :: integer
-  def checksum(number, base) do
-    number
-    |> String.split("", trim: true)
-    |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n, base)|acc] end)
-    |> double(base, 0)
-    |> rem base
+  def checksum(number, base) when is_binary(number) do
+    case number |> parse(base) do
+      {:ok, parsed} -> {:ok, parsed |> double(base, 0) |> rem(base)}
+      :error -> :error
+    end
   end
 
   def double([], _, acc), do: acc
   def double([x], _, acc), do: x + acc
-  def double([x,y|tail], base, acc), do: double(tail, base, acc + x + sum(y * 2, base))
+  def double([x, y | tail], base, acc), do: double(tail, base, acc + x + sum(y * 2, base))
 
   defp sum(number, base) when number >= base, do: number - base + 1
   defp sum(number, _), do: number
+
+  defp parse(value, base), do: value |> String.split("", trim: true) |> do_parse(base, [])
+
+  defp do_parse([char | tail], base, acc) do
+    case char |> Integer.parse(base) do
+      {parsed, ""} -> do_parse tail, base, [parsed | acc]
+      _ -> :error
+    end
+  end
+  defp do_parse([], _base, acc), do: {:ok, acc}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,6 @@ defmodule Luhn.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:excoveralls, "~> 0.3", only: :dev},
-     {:power_assert, "~> 0.0.3", only: :test},
      {:benchfella, "~> 0.3", only: :bench}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Luhn.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.lock
+++ b/mix.lock
@@ -4,5 +4,4 @@
   "hackney": {:hex, :hackney, "1.1.0"},
   "idna": {:hex, :idna, "1.0.2"},
   "jsx": {:hex, :jsx, "2.4.0"},
-  "power_assert": {:hex, :power_assert, "0.0.3"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,11 @@
-%{"benchfella": {:hex, :benchfella, "0.3.2"},
-  "excoveralls": {:hex, :excoveralls, "0.3.10"},
-  "exjsx": {:hex, :exjsx, "3.1.0"},
-  "hackney": {:hex, :hackney, "1.1.0"},
-  "idna": {:hex, :idna, "1.0.2"},
-  "jsx": {:hex, :jsx, "2.4.0"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+%{"benchfella": {:hex, :benchfella, "0.3.3", "bbde48b5fe1ef556baa7ad933008e214e050e81ddb0916350715f5759fb35c0c", [:mix], []},
+  "certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "excoveralls": {:hex, :excoveralls, "0.6.1", "9e946b6db84dba592f47632157ecd135a46384b98a430fd16007dc910c70348b", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
+  "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
+  "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}

--- a/test/luhn_test.exs
+++ b/test/luhn_test.exs
@@ -59,4 +59,9 @@ defmodule LuhnTest do
     assert !Luhn.valid? "abc12392b", 16
     assert !Luhn.valid? "abc123a", 16
   end
+
+  test "Invalid random string" do
+    assert !Luhn.valid? "01:00:00:00:00:00*AB", 10
+    assert !Luhn.valid? "01:00:00:00:00:00*AB", 16
+  end
 end


### PR DESCRIPTION
Hey, I ran across this error when trying to validate inputs from clients. It turns out people can be quite creative when typing in IMEIs. Your implementation assumes that codepoints are at least parsable to integer which may not be true. Please review my proposed changes.