### PR TITLE
Fix compile warnings caused by pipe operator

### DIFF
--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -4,7 +4,7 @@ defmodule Luhn do
   @spec valid?(integer, 2..36) :: boolean
   def valid?(number, base \\ 10) do
     checksum(number, base)
-    |> Kernel.== 0
+    |> Kernel.== (0)
   end
 
   def checksum(number, base \\ 10)
@@ -22,7 +22,7 @@ defmodule Luhn do
     |> String.split("", trim: true)
     |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n, base)|acc] end)
     |> double(base, 0)
-    |> rem base
+    |> rem(base)
   end
 
   def double([], _, acc), do: acc

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule Luhn.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     deps: deps]
+     deps: deps()
+    ]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
The current master creates compile warnings like the one below. My PR fixes that.

```
warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/luhn.ex:7

warning: parentheses are required when piping into a function call. For example:

    foo 1 |> bar 2 |> baz 3

is ambiguous and should be written as

    foo(1) |> bar(2) |> baz(3)

Ambiguous pipe found at:
  lib/luhn.ex:25

warning: redefining module Luhn (current version loaded from /home/brolaugh/code/personnummer/_build/dev/lib/luhnatex/ebin/Elixir.Luhn.beam)
  lib/luhn.ex:1

Generated luhn app
==> personnummer
Compiling 1 file (.ex)
Generated personnummer app
```