### PR TITLE
Switch to using Integer.digits/2 and add some docs and specs

### DIFF
--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -1,7 +1,28 @@
 defmodule Luhn do
+  @moduledoc """
+  Functions for validating Credit Card numbers using Luhn checksums.
 
-  @spec valid?(integer, 2..36) :: boolean
-  def valid?(number, base \\ 10) do
+  Credit card numbers may be of arbitrary length and in arbitrary base.
+  """
+
+  @doc """
+  Evaluates a given credit card number for its validity, with an optionally provided base.
+
+  # Examples
+      # Accepts a string
+      iex(1)> Luhn.valid?("378282246310005")
+      true
+
+      # Or an integer
+      iex(2)> Luhn.valid?(378282246310005)
+      true
+
+      # Works with Hexadecimal as well
+      iex(3)> Luhn.valid?(0x1580BB2EA8875, 16)
+      true
+  """
+  @spec valid?(number :: integer | String.t, base :: 2..36) :: boolean
+  def valid?(number, base \\ 10) when base >= 2 do
     checksum(number, base)
     |> Kernel.==(0)
   end

--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -5,6 +5,8 @@ defmodule Luhn do
   Credit card numbers may be of arbitrary length and in arbitrary base.
   """
 
+  defguardp valid_base(base) when base >= 2
+
   @doc """
   Evaluates a given credit card number for its validity, with an optionally provided base.
 
@@ -21,23 +23,23 @@ defmodule Luhn do
       iex(3)> Luhn.valid?(0x1580BB2EA8875, 16)
       true
   """
-  @spec valid?(number :: integer | String.t, base :: 2..36) :: boolean
-  def valid?(number, base \\ 10) when base >= 2 do
+  @spec valid?(number :: integer | String.t, base :: integer) :: boolean
+  def valid?(number, base \\ 10) when valid_base(base) do
     checksum(number, base)
     |> Kernel.==(0)
   end
 
   def checksum(number, base \\ 10)
 
-  @spec checksum(binary, 2..36) :: integer
-  def checksum(number, base) when is_binary(number) do
+  @spec checksum(binary, integer) :: integer
+  def checksum(number, base) when is_binary(number) and valid_base(base) do
     number
     |> String.to_integer(base)
     |> checksum(base)
   end
 
-  @spec checksum(integer, 2..36) :: integer
-  def checksum(number, base) do
+  @spec checksum(integer, integer) :: integer
+  def checksum(number, base) when valid_base(base) do
     number
     |> Integer.digits(base)
     |> Enum.reverse
@@ -53,4 +55,5 @@ defmodule Luhn do
   @spec sum(integer, integer) :: integer
   defp sum(number, base) when number >= base, do: number - base + 1
   defp sum(number, _), do: number
+
 end

--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -1,5 +1,4 @@
 defmodule Luhn do
-  require Integer
 
   @spec valid?(integer, 2..36) :: boolean
   def valid?(number, base \\ 10) do

--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -29,26 +29,28 @@ defmodule Luhn do
 
   def checksum(number, base \\ 10)
 
-  @spec checksum(integer, 2..36) :: integer
-  def checksum(number, base) when is_integer(number) do
+  @spec checksum(binary, 2..36) :: integer
+  def checksum(number, base) when is_binary(number) do
     number
-    |> Integer.to_string(base)
+    |> String.to_integer(base)
     |> checksum(base)
   end
 
-  @spec checksum(String.t, 2..36) :: integer
+  @spec checksum(integer, 2..36) :: integer
   def checksum(number, base) do
     number
-    |> String.split("", trim: true)
-    |> Enum.reduce([], fn(n, acc) -> [String.to_integer(n, base)|acc] end)
+    |> Integer.digits(base)
+    |> Enum.reverse
     |> double(base, 0)
     |> rem(base)
   end
 
+  @spec double([integer, ...], integer, integer) :: integer
   def double([], _, acc), do: acc
   def double([x], _, acc), do: x + acc
   def double([x,y|tail], base, acc), do: double(tail, base, acc + x + sum(y * 2, base))
 
+  @spec sum(integer, integer) :: integer
   defp sum(number, base) when number >= base, do: number - base + 1
   defp sum(number, _), do: number
 end


### PR DESCRIPTION
I've been using the Luhn algorithim as an interview question for a few years now, and have found some small efficiency gains that can be made over the standard string splitting version, with regards to elixir.

If you use [`Integer.digits/2`](https://hexdocs.pm/elixir/Integer.html#digits/2) instead of `String.split/3`, you get a non-insubstantial performance boost. This, in addition to the use of Enum.reverse instead of a reducer, makes this variant over 3.5x more performant.

Additionally, I added and updated some typespecs and added some documentation blocks

## Benchmarks
Old variant:
```
Settings:
  duration:      1.0 s

## BasicBench
[12:06:30] 1/1: luhn

Finished in 2.03 seconds

## BasicBench
luhn      500000   3.18 µs/op
```

This PR:
```
Settings:
  duration:      1.0 s

## BasicBench
[12:07:03] 1/1: luhn

Finished in 9.99 seconds

## BasicBench
luhn    10000000   0.90 µs/op
```