### PR TITLE
add ability to calculate or append check digits

### DIFF
--- a/lib/luhn.ex
+++ b/lib/luhn.ex
@@ -47,6 +47,45 @@ defmodule Luhn do
     |> rem(base)
   end
 
+  defp distance_from_base(checksum, _base) when checksum == 0, do: 0
+  defp distance_from_base(checksum,  base), do: base - checksum
+
+  @doc """
+  Calculates the check digit for a number prefix
+
+  # Example
+      # Accepts an integer
+      iex> Luhn.check_digit(37828224631000)
+      5
+
+      # Accepts an integer
+      iex> Luhn.check_digit(37828224631007)
+      0
+  """
+  @spec check_digit(integer, integer) :: integer
+  def check_digit(number, base \\ 10) when valid_base(base) do
+    number
+    |> Kernel.*(base)
+    |> checksum(base)
+    |> distance_from_base(base)
+  end
+
+  @doc """
+  Appends the check digit to a number prefix
+
+  # Example
+      # Accepts an integer
+      iex> Luhn.append_check_digit(37828224631000)
+      378282246310005
+  """
+  @spec append_check_digit(integer, integer) :: integer
+  def append_check_digit(number, base \\ 10) when valid_base(base) do
+    number
+    |> Integer.digits()
+    |> Kernel.++([check_digit(number, base)])
+    |> Integer.undigits()
+  end
+
   @spec double([integer, ...], integer, integer) :: integer
   def double([], _, acc), do: acc
   def double([x], _, acc), do: x + acc

--- a/test/luhn_test.exs
+++ b/test/luhn_test.exs
@@ -1,6 +1,8 @@
 defmodule LuhnTest do
   use ExUnit.Case
 
+  doctest Luhn
+
   test "American Express" do
     assert Luhn.valid? "378282246310005"
     assert Luhn.valid? "371449635398431"


### PR DESCRIPTION
FWIW, while I did this I enabled doctests. I noticed that you've got an existing doctest which isn't passing -- 0x1580BB2EA8875 gets treated as the same as 378282246310005, but appears to otherwise be an example of base 16 use.

power_assert is also causing deprecation warnings & I left that alone too.