### PR TITLE
setup-beam does not provide OTP version under 24 on ubuntu-22.04

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,7 +9,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
SEE: https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp